### PR TITLE
Fix sketch initialization error caused by incorrect use of memset

### DIFF
--- a/Sketch/FlowSize/CMSACSketch.h
+++ b/Sketch/FlowSize/CMSACSketch.h
@@ -37,8 +37,7 @@ CMSACSketch::CMSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -97,7 +96,6 @@ void CMSACSketch::Insert(cuc *str){
 }
 
 uint CMSACSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
     uint Min = INF_SAC;
     for(uint i = 0; i < d; ++i){
         uint cid = hf->Str2Int(str, i)%w;
@@ -123,7 +121,6 @@ uint CMSACSketch::Query(cuc *str, bool ml){
 }
 
 void CMSACSketch::PrintCounter(cuc* str, uint acc_val){
-	memset(t, 0, sizeof(t));
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = CQuery(i, cid);

--- a/Sketch/FlowSize/CMSketch.h
+++ b/Sketch/FlowSize/CMSketch.h
@@ -28,8 +28,7 @@ private:
 CMSketch::CMSketch(uint d, uint w):d(d), w(w){
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		 sketch[i] = new ushort[w]();
 	}
 	hf = new HashFunction();
 	para = new float[d];
@@ -59,7 +58,6 @@ void CMSketch::Insert(cuc *str){
 }
 
 uint CMSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
 
 	uint Min = INF_SHORT;
 	for(uint i = 0; i < d; ++i){

--- a/Sketch/FlowSize/CUSACSketch.h
+++ b/Sketch/FlowSize/CUSACSketch.h
@@ -47,8 +47,7 @@ CUSACSketch::CUSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -107,7 +106,6 @@ void CUSACSketch::ConfigThres(uint *thres){
 }
 
 void CUSACSketch::Insert(cuc *str){
-	memset(t, 0, sizeof(t));
 	uint Min = INF_SHORT;
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
@@ -123,7 +121,6 @@ void CUSACSketch::Insert(cuc *str){
 }
 
 uint CUSACSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
     uint Min = INF_SAC;
     for(uint i = 0; i < d; ++i){
         uint cid = hf->Str2Int(str, i)%w;
@@ -145,7 +142,6 @@ uint CUSACSketch::Query(cuc *str, bool ml){
 }
 
 void CUSACSketch::PrintCounter(cuc* str, uint acc_val){
-	memset(t, 0, sizeof(t));
 	for(uint i = 0; i < d; ++i) {
         uint cid = hf->Str2Int(str, i) % w;
         t[i] = CQuery(i, cid);

--- a/Sketch/FlowSize/CUSketch.h
+++ b/Sketch/FlowSize/CUSketch.h
@@ -32,8 +32,7 @@ private:
 CUSketch::CUSketch(uint d, uint w):d(d), w(w){
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new ushort[w]();
 	}
 	hf = new HashFunction();
 	para = new float[d];
@@ -53,7 +52,6 @@ CUSketch::~CUSketch(){
 }
 
 void CUSketch::Insert(cuc *str){
-	memset(t, 0, sizeof(t));
 	uint Min = INF_SHORT;
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
@@ -71,7 +69,6 @@ void CUSketch::Insert(cuc *str){
 }
 
 uint CUSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
     uint Min = INF_SHORT;
     for(uint i = 0; i < d; ++i){
         uint cid = hf->Str2Int(str, i)%w;
@@ -94,8 +91,6 @@ uint CUSketch::Query(cuc *str, bool ml){
 }
 
 void CUSketch::PrintCounter(cuc* str, uint acc_val){
-	memset(t, 0, sizeof(t));
-
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = sketch[i][cid];

--- a/Sketch/FlowSize/PSACSketch.h
+++ b/Sketch/FlowSize/PSACSketch.h
@@ -37,8 +37,7 @@ PSACSketch::PSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -105,7 +104,7 @@ uint PSACSketch::Query(cuc *str, bool ml){
 		return sum;
 	}
 	else{
-		memset(t, 0, sizeof(t));
+		 
 		for(uint i = 0; i < d; ++i){
 			uint cid = hf->Str2Int(str, i)%w;
 			t[i] = CQuery(i, cid);
@@ -121,7 +120,7 @@ uint PSACSketch::Query(cuc *str, bool ml){
 }
 
 void PSACSketch::PrintCounter(cuc* str, uint acc_val){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = CQuery(i, cid);

--- a/Sketch/FlowSize/PSketch.h
+++ b/Sketch/FlowSize/PSketch.h
@@ -28,8 +28,8 @@ PSketch::PSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		 sketch[i] = new ushort[w]();
+		 
 	}
 	hf = new HashFunction();
 	para = new float[d];
@@ -65,7 +65,7 @@ uint PSketch::Query(cuc *str, bool ml){
 		return sum;
 	}
 	else{
-		memset(t, 0, sizeof(t));
+		 
 		for(uint i = 0; i < d; ++i){
 			uint cid = hf->Str2Int(str, i)%w;
 			t[i] = sketch[i][cid];
@@ -81,7 +81,7 @@ uint PSketch::Query(cuc *str, bool ml){
 }
 
 void PSketch::PrintCounter(cuc* str, uint acc_val) {
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = sketch[i][cid];

--- a/Sketch/TopK/CMSACSketch.cpp
+++ b/Sketch/TopK/CMSACSketch.cpp
@@ -4,8 +4,8 @@ CMSACSketch::CMSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
+		 
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -64,7 +64,7 @@ void CMSACSketch::Insert(cuc *str){
 }
 
 uint CMSACSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
+	 
 	if(!ml){
 		uint Min = INF_SAC;
 		for(uint i = 0; i < d; ++i){
@@ -88,7 +88,7 @@ uint CMSACSketch::Query(cuc *str, bool ml){
 }
 
 void CMSACSketch::PrintCounter(cuc* str){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = CQuery(i, cid);

--- a/Sketch/TopK/CMSketch.cpp
+++ b/Sketch/TopK/CMSketch.cpp
@@ -3,8 +3,8 @@
 CMSketch::CMSketch(uint d, uint w):d(d), w(w){
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		 sketch[i] = new ushort[w]();
+		 
 	}
 	hf = new HashFunction();
 	para = new float[2*d-1];
@@ -31,7 +31,7 @@ void CMSketch::Insert(cuc *str){
 }
 
 uint CMSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
+	 
 	if(!ml){
 		uint Min = INF_SHORT;
 		for(uint i = 0; i < d; ++i){

--- a/Sketch/TopK/CUSACSketch.cpp
+++ b/Sketch/TopK/CUSACSketch.cpp
@@ -4,8 +4,8 @@ CUSACSketch::CUSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
+		 
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -64,7 +64,7 @@ void CUSACSketch::ConfigThres(uint *thres){
 }
 
 void CUSACSketch::Insert(cuc *str){
-	memset(t, 0, sizeof(t));
+	 
 	uint Min = INF_SHORT;
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
@@ -80,7 +80,7 @@ void CUSACSketch::Insert(cuc *str){
 }
 
 uint CUSACSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
+	 
 	if(!ml){
 		uint Min = INF_SAC;
 		for(uint i = 0; i < d; ++i){
@@ -104,7 +104,7 @@ uint CUSACSketch::Query(cuc *str, bool ml){
 }
 
 void CUSACSketch::PrintCounter(cuc* str){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = CQuery(i, cid);

--- a/Sketch/TopK/CUSketch.cpp
+++ b/Sketch/TopK/CUSketch.cpp
@@ -3,8 +3,8 @@
 CUSketch::CUSketch(uint d, uint w):d(d), w(w){
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		 sketch[i] = new ushort[w]();
+		 
 	}
 	hf = new HashFunction();
 	para = new float[2*d-1];
@@ -24,7 +24,7 @@ CUSketch::~CUSketch(){
 }
 
 void CUSketch::Insert(cuc *str){
-	memset(t, 0, sizeof(t));
+	 
 	uint Min = INF_SHORT;
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
@@ -40,7 +40,7 @@ void CUSketch::Insert(cuc *str){
 }
 
 uint CUSketch::Query(cuc *str, bool ml){
-	memset(t, 0, sizeof(t));
+	 
 	if(!ml){
 		uint Min = INF_SHORT;
 		for(uint i = 0; i < d; ++i){
@@ -64,7 +64,7 @@ uint CUSketch::Query(cuc *str, bool ml){
 }
 
 void CUSketch::PrintCounter(cuc* str){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = sketch[i][cid];

--- a/Sketch/TopK/PSACSketch.cpp
+++ b/Sketch/TopK/PSACSketch.cpp
@@ -4,8 +4,8 @@ PSACSketch::PSACSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new uchar*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new uchar[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		sketch[i] = new uchar[w]();
+		 
 	}
 	hf = new HashFunction();
 	r = new uint[8];
@@ -72,7 +72,7 @@ uint PSACSketch::Query(cuc *str, bool ml){
 		return sum;
 	}
 	else{
-		memset(t, 0, sizeof(t));
+		 
 		for(uint i = 0; i < d; ++i){
 			uint cid = hf->Str2Int(str, i)%w;
 			t[i] = CQuery(i, cid);
@@ -86,7 +86,7 @@ uint PSACSketch::Query(cuc *str, bool ml){
 }
 
 void PSACSketch::PrintCounter(cuc* str){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = CQuery(i, cid);

--- a/Sketch/TopK/PSketch.cpp
+++ b/Sketch/TopK/PSketch.cpp
@@ -4,8 +4,8 @@ PSketch::PSketch(uint d, uint w):d(d), w(w){
 	srand(time(0));
 	sketch = new ushort*[d];
 	for(uint i = 0; i < d; ++i){
-		sketch[i] = new ushort[w];
-		memset(sketch[i], 0, sizeof(sketch[i]));
+		 sketch[i] = new ushort[w]();
+		 
 	}
 	hf = new HashFunction();
 	para = new float[2*d-1];
@@ -38,7 +38,7 @@ uint PSketch::Query(cuc *str, bool ml){
 		return sum;
 	}
 	else{
-		memset(t, 0, sizeof(t));
+		 
 		for(uint i = 0; i < d; ++i){
 			uint cid = hf->Str2Int(str, i)%w;
 			t[i] = sketch[i][cid];
@@ -52,7 +52,7 @@ uint PSketch::Query(cuc *str, bool ml){
 }
 
 void PSketch::PrintCounter(cuc* str){
-	memset(t, 0, sizeof(t));
+	 
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = sketch[i][cid];

--- a/sketch_dpdk/trunk/sketch_expmt/NewCISketch_v1/CUSketch.h
+++ b/sketch_dpdk/trunk/sketch_expmt/NewCISketch_v1/CUSketch.h
@@ -85,7 +85,7 @@ uint CUSketch::Query(cuc *str, bool ml){
 
 void CUSketch::PrintCounter(cuc* str, uint acc_val){
 	memset(t, 0, sizeof(t));
-
+	
 	for(uint i = 0; i < d; ++i){
 		uint cid = hf->Str2Int(str, i)%w;
 		t[i] = sketch[i][cid];


### PR DESCRIPTION
Hi,
I am an intern, working under the guidance of Professor Huang Qun.
I found a problem while reading the code.

bug: memset(sketch[i], 0, sizeof(sketch[i]))  **"sizeof(sketch[i])"**
What we get is the size of the pointer, not the size of the memory that needs to be initialized.
This causes only first 4 unsigned short in each row of sketch to be initialized.
The rest of the values are uncontrolled, depending on the state of the system, and sometimes lead to erroneous results
fix: sketch[i] = new uchar[w];  -> sketch[i] = new uchar[w]**()**;

"memset(t, 0, sizeof(t));"
Same mistake and redundant actually.